### PR TITLE
[#365] Support frozen array in  option

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -86,7 +86,7 @@ module FastJsonapi
       raise ArgumentError.new("`params` option passed to serializer must be a hash") unless @params.is_a?(Hash)
 
       if options[:include].present?
-        @includes = options[:include].delete_if(&:blank?).map(&:to_sym)
+        @includes = options[:include].reject(&:blank?).map(&:to_sym)
         self.class.validate_includes!(@includes)
       end
     end

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -473,6 +473,16 @@ describe FastJsonapi::ObjectSerializer do
         options[:include] = [:actors]
         expect(serializable_hash['included']).to be_blank
       end
+
+    end
+  end
+
+  context 'when include has frozen array' do
+    let(:options) { { include: [:actors].freeze }}
+    let(:json) { MovieOptionalRelationshipSerializer.new(movie, options).serialized_json }
+
+    it 'does not raise and error' do
+      expect(json['included']).to_not be_blank
     end
   end
 


### PR DESCRIPTION
Fix error raised when we pass frozen array to `include` option.

https://github.com/Netflix/fast_jsonapi/blob/fdcaed6f0d72cf793b3117a5081de5fbd7466574/lib/fast_jsonapi/object_serializer.rb#L89